### PR TITLE
Use platform-agnostic TFM

### DIFF
--- a/PointerToolkit.TerraFX.Interop.Windows/PointerToolkit.TerraFX.Interop.Windows.csproj
+++ b/PointerToolkit.TerraFX.Interop.Windows/PointerToolkit.TerraFX.Interop.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="Version.Generated.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>$(VersionPrefix)</Version>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
Hi.. If its set-up like this for paint.net reasons, feel free to close. But at the moment targeting the -windows TFM is blocking me from using this package. [TerraFX.Interop.Windows uses the general TFM, not the windows specific version](https://github.com/terrafx/terrafx.interop.windows/blob/d5c0ab195c6e522e383e6610d42e07b5d3db6654/sources/Interop/Windows/TerraFX.Interop.Windows.csproj#L7)